### PR TITLE
테이블명 변경: `user_account` -> `admin_account`

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping("/admin/members")
 @Controller
-public class AdminUserAccountController {
+public class AdminAccountController {
 
     @GetMapping
     public String members(

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/admin/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/admin/AdminAccount.java
@@ -1,4 +1,4 @@
-package com.fastcampus.projectboardadmin.domain.user;
+package com.fastcampus.projectboardadmin.domain.admin;
 
 import com.fastcampus.projectboardadmin.domain.common.AuditingFields;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
@@ -22,7 +22,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id
     @Column(nullable = false, length = 50)
     private String userId;
@@ -44,10 +44,10 @@ public class UserAccount extends AuditingFields {
     @Setter
     private String memo;
 
-    protected UserAccount() {
+    protected AdminAccount() {
     }
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -58,12 +58,12 @@ public class UserAccount extends AuditingFields {
         this.modifiedBy = createdBy;
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
@@ -81,8 +81,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return this.getUserId() != null && this.getUserId().equals(userAccount.getUserId());
+        if (!(o instanceof AdminAccount adminAccount)) return false;
+        return this.getUserId() != null && this.getUserId().equals(adminAccount.getUserId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,57 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.admin.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.contant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,14 +1,13 @@
 package com.fastcampus.projectboardadmin.dto;
 
+import com.fastcampus.projectboardadmin.domain.admin.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
-import com.fastcampus.projectboardadmin.domain.user.UserAccount;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,38 +18,12 @@ public record UserAccountDto(
         String modifiedBy
 ) {
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
-    }
-
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -42,7 +42,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -53,8 +53,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.admin.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.user.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- 테스트 계정
-insert into user_account
+insert into admin_account
 (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by)
 values ('soono', 'asdf1234', 'ADMIN', 'soono', 'soono@mail.com', 'I am soono.', now(), 'soono', now(), 'soono'),
-       ('mark', '{asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'soono', now(), 'soono'),
+       ('mark', 'asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'soono', now(), 'soono'),
        ('susan', 'asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'soono', now(),
         'soono'),
        ('jim', 'asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'soono', now(), 'soono')

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountManagementControllerTest.java
@@ -16,11 +16,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("View 컨트롤러 - 회원 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(UserAccountManagementController.class)
-class UserAccountManagementControllerTest {
+class AdminAccountManagementControllerTest {
 
     private final MockMvc mvc;
 
-    public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
+    public AdminAccountManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAdminAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAdminAccountControllerTest.java
@@ -15,11 +15,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("View 컨트롤러 - 어드민 회원")
 @Import(SecurityConfig.class)
 @WebMvcTest(AdminUserAccountController.class)
-class AdminUserAccountControllerTest {
+class AdminAdminAccountControllerTest {
 
     private final MockMvc mvc;
 
-    public AdminUserAccountControllerTest(@Autowired MockMvc mvc) {
+    public AdminAdminAccountControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAdminAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAdminAccountControllerTest.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 어드민 회원")
 @Import(SecurityConfig.class)
-@WebMvcTest(AdminUserAccountController.class)
+@WebMvcTest(AdminAccountController.class)
 class AdminAdminAccountControllerTest {
 
     private final MockMvc mvc;

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -3,6 +3,7 @@ package com.fastcampus.projectboardadmin.controller;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
@@ -104,8 +105,8 @@ class ArticleCommentManagementControllerTest {
         );
     }
 
-    private AdminAccountDto createUserAccountDto() {
-        return AdminAccountDto.of(
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
                 "soonoTest",
                 Set.of(RoleType.ADMIN),
                 "soono-test@email.com",

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -2,7 +2,7 @@ package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
@@ -104,10 +104,9 @@ class ArticleCommentManagementControllerTest {
         );
     }
 
-    private UserAccountDto createUserAccountDto() {
-        return UserAccountDto.of(
+    private AdminAccountDto createUserAccountDto() {
+        return AdminAccountDto.of(
                 "soonoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "soono-test@email.com",
                 "soono-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -3,6 +3,7 @@ package com.fastcampus.projectboardadmin.controller;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleDto;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
@@ -105,8 +106,8 @@ class ArticleManagementControllerTest {
         );
     }
 
-    private AdminAccountDto createUserAccountDto() {
-        return AdminAccountDto.of(
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
                 "soonoTest",
                 Set.of(RoleType.ADMIN),
                 "soono-test@email.com",

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -2,7 +2,7 @@ package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleDto;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
@@ -105,10 +105,9 @@ class ArticleManagementControllerTest {
         );
     }
 
-    private UserAccountDto createUserAccountDto() {
-        return UserAccountDto.of(
+    private AdminAccountDto createUserAccountDto() {
+        return AdminAccountDto.of(
                 "soonoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "soono-test@email.com",
                 "soono-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -31,7 +31,7 @@ class JpaRepositoryTest {
 
     @DisplayName("회원 정보 select 테스트")
     @Test
-    void givenUserAccounts_whenSelecting_thenWorksFine() {
+    void givenAdminAccounts_whenSelecting_thenWorksFine() {
         // Given
 
         // When
@@ -45,7 +45,7 @@ class JpaRepositoryTest {
 
     @DisplayName("회원 정보 insert 테스트")
     @Test
-    void givenUserAccount_whenInserting_thenWorksFine() {
+    void givenAdminAccount_whenInserting_thenWorksFine() {
         // Given
         long previousCount = adminAccountRepository.count();
         AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
@@ -59,7 +59,7 @@ class JpaRepositoryTest {
 
     @DisplayName("회원 정보 update 테스트")
     @Test
-    void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
+    void givenAdminAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
         AdminAccount adminAccount = adminAccountRepository.getReferenceById("soono");
         adminAccount.addRoleType(RoleType.DEVELOPER);
@@ -77,7 +77,7 @@ class JpaRepositoryTest {
 
     @DisplayName("회원 정보 delete 테스트")
     @Test
-    void givenUserAccount_whenDeleting_thenWorksFine() {
+    void givenAdminAccount_whenDeleting_thenWorksFine() {
         // Given
         long previousCount = adminAccountRepository.count();
         AdminAccount adminAccount = adminAccountRepository.getReferenceById("soono");

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.repository;
 
+import com.fastcampus.projectboardadmin.domain.admin.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
-import com.fastcampus.projectboardadmin.domain.user.UserAccount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
@@ -35,10 +35,10 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
@@ -47,27 +47,27 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("회원 정보 update 테스트")
     @Test
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("soono");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("soono");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -79,14 +79,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("soono");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("soono");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount - 1);
     }
 
 

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboardadmin.service;
 
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.dto.properties.ProjectProperties;
@@ -171,7 +172,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "soonoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "soono-test@email.com",
                 "soono-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboardadmin.service;
 
 import com.fastcampus.projectboardadmin.domain.contant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.dto.article.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.properties.ProjectProperties;
@@ -170,7 +171,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "soonoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "soono-test@email.com",
                     "soono-test",


### PR DESCRIPTION
이 `PR`은 기존의 어드민 회원 테이블명을 변경한다.

This closes #25 